### PR TITLE
Generic header for new files [#5]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,40 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
+
+# Created by https://www.gitignore.io/api/macos
+# Edit at https://www.gitignore.io/?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://www.gitignore.io/api/macos
+
 # Code Injection
 #
 # After new code Injection tools there's a generated folder /iOSInjectionProject

--- a/Aspire Budgeting.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Aspire Budgeting.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>FILEHEADER</key>
+<string>
+// ___FILENAME___
+// ___PRODUCTNAME___
+//
+</string>
+</dict>
+</plist>


### PR DESCRIPTION
Addresses #5.

Adds `IDETemplateMacros.plist ` to `xcshareddata`. 

Now, when new files are created, they will have a generic header with file and product name. E.g.:

    //
    // FileName.swift
    // Aspire Budgeting
    //

Also adds git exclusions for `macOS`. 